### PR TITLE
Cleaned up Javadoc for class headers. Fixed synonym issues with "go a…

### DIFF
--- a/src/com/codebusters/game/Chapter.java
+++ b/src/com/codebusters/game/Chapter.java
@@ -2,6 +2,8 @@ package com.codebusters.game;
 /**
  *Chapter Class contains the data for each chapter
  *
+ * Author: Dustin Morris
+ *
  **/
 
 import java.util.ArrayList;

--- a/src/com/codebusters/game/GameState.java
+++ b/src/com/codebusters/game/GameState.java
@@ -5,9 +5,8 @@ package com.codebusters.game;
  * access to display the interface for the player. It is updated by Game.java.
  * <p>
  * Authors: Bradley Pratt & Debbie Bitencourt
- * Last Edited: 01/29/2021
+ * Last Edited: 02/08/2021
  */
-
 import java.io.*;
 import java.util.ArrayList;
 
@@ -56,7 +55,6 @@ public class GameState implements Serializable {
         }
         return false;
     }
-
 
     //make GameState as a Singleton to be used in other Classes.
     public static GameState getInstance(){

--- a/src/com/codebusters/game/Items.java
+++ b/src/com/codebusters/game/Items.java
@@ -1,7 +1,4 @@
 package com.codebusters.game;
-
-import java.io.Serializable;
-
 /**
  * Items class represents the individual items the player can have in their inventory.
  * Each items has a name, an id number for tracking in an internal database, and a count
@@ -10,6 +7,7 @@ import java.io.Serializable;
  * Authors: Bradley Pratt & Debbie Bitencourt
  * Last Edited: 01/31/2021
  */
+import java.io.Serializable; //for saving the game
 
 public class Items implements Serializable {
     private String name;

--- a/src/com/codebusters/game/TextParser.java
+++ b/src/com/codebusters/game/TextParser.java
@@ -6,7 +6,7 @@ package com.codebusters.game;
  * Game.java can then pull.
  * <p>
  * Authors: Bradley Pratt & Debbie Bitencourt
- * Last Edited: 02/05/2021
+ * Last Edited: 02/09/2021
  */
 import java.util.*;
 
@@ -21,10 +21,10 @@ public class TextParser {
             Arrays.asList("use", "light", "threaten", "utilize", "apply", "employ", "ignite", "burn", "intimidate", "bully", "terrorize", "frighten", "scare")
     );
     private final List<String> PLACES_VERBS_ENTRY = new ArrayList<>(
-            Arrays.asList("enter", "search", "explore", "go", "access", "look", "invade", "forage")
+            Arrays.asList("enter", "search", "explore", "access", "look", "invade", "forage")
     );
     private final List<String> PLACES_VERBS_EXIT = new ArrayList<>(
-            Arrays.asList("leave", "exit", "run", "walk", "go", "escape", "depart", "retreat", "retire")
+            Arrays.asList("leave", "exit", "run", "walk", "escape", "depart", "retreat", "retire")
     );
     private final List<String> PLACES_NOUNS_1 = new ArrayList<>(
             Arrays.asList("city", "town", "village", "settlement", "around")
@@ -37,6 +37,9 @@ public class TextParser {
     );
     private final List<String> PLACES_NOUNS_4 = new ArrayList<>(
             Arrays.asList("bedroom", "room", "suite")
+    );
+    private final List<String> PLACES_NOUNS_5 = new ArrayList<>(
+            Arrays.asList("cabinet", "cabinets")
     );
     private final List<String> VERBS1 = new ArrayList<>(
             Arrays.asList("go", "skip")
@@ -149,6 +152,7 @@ public class TextParser {
             || (PLACES_NOUNS_2.contains(reqWord) && PLACES_NOUNS_2.contains(word))
             || (PLACES_NOUNS_3.contains(reqWord) && PLACES_NOUNS_3.contains(word))
             || (PLACES_NOUNS_4.contains(reqWord) && PLACES_NOUNS_4.contains(word))
+            || (PLACES_NOUNS_5.contains(reqWord) && PLACES_NOUNS_5.contains(word))
             || (VERBS1.contains(reqWord) && VERBS1.contains(word))
             || (VERBS2.contains(reqWord) && VERBS2.contains(word))
         );

--- a/src/com/codebusters/game/Viewer.java
+++ b/src/com/codebusters/game/Viewer.java
@@ -1,13 +1,12 @@
 package com.codebusters.game;
-
 /**
  * Viewer.java is where using GUI the game can be experienced and played in a separate window.
  * The GUI is designed to be visually appealing and user friendly.
  * Player using the input field can progress through the game.
  * <p>
  * Author: Aliona (main GUI), Dustin (save/load).
+ * Last Edited: 02/09/2021
  */
-
 import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.border.Border;
@@ -154,9 +153,7 @@ public class Viewer implements ActionListener {
 
     //*************** METHODS ***************
     public void updateViewer() {
-
         titleName.setText(GameState.getInstance().getSceneTitle());
-//        container.add(titleName);
 
         //create StringBuilder for inventory to be displayed as string in the inventory text area.
         StringBuilder inv = new StringBuilder();


### PR DESCRIPTION
…round" incorrectly translating to "enter city" as well as "cabinet" & "cabinets" being swappable.